### PR TITLE
depends: correct spirv-headers

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -51,7 +51,7 @@ depends=(
 )
 
 makedepends=('git' 'autoconf' 'ncurses' 'bison' 'perl' 'fontforge' 'flex'
-    'gcc>=4.5.0-2' 'spirv-headers-git'
+    'gcc>=4.5.0-2' 'spirv-headers'
     'vulkan-headers' 'vulkan-icd-loader'
     'lib32-vulkan-icd-loader' 'wine'
 )


### PR DESCRIPTION
Shouldn't this just be spirv-headers since that's one of the packages made from spirv-tools-git?