### PR TITLE
Add glslang to makedepends for makechrootpkg building

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -56,6 +56,7 @@ makedepends=('git' 'autoconf' 'ncurses' 'bison' 'perl' 'fontforge' 'flex'
     'gcc>=4.5.0-2' 'spirv-headers'
     'vulkan-headers' 'vulkan-icd-loader'
     'lib32-vulkan-icd-loader' 'wine'
+    'glslang'
 )
 
 if [ "$_vkd3d_source" = "https://github.com/HansKristian-Work/vkd3d-proton" ] && [ "$_fork_disable_meson" = "false" ]; then


### PR DESCRIPTION
I was having the following issue when using `makechrootpkg` to build in a clean chroot:

```
+ exec meson setup --prefix /usr --libexecdir lib --sbindir bin --buildtype plain --auto-features enabled --wrap-mode nodownload -D b_lto=true -D b_pie=true /build/vkd3d-proton-tkg-git/src/HansKristian-Work-vkd3d-proton /build/vkd3d-proton-tkg-git/src/vkd3d-proton-tkg-git --libdir lib --buildtype release
The Meson build system
Version: 0.55.1
Source dir: /build/vkd3d-proton-tkg-git/src/HansKristian-Work-vkd3d-proton
Build dir: /build/vkd3d-proton-tkg-git/src/vkd3d-proton-tkg-git
Build type: native build
Project name: vkd3d
Project version: 1.1
Using 'CC' from environment with value: 'gcc -m64'
Using 'CFLAGS' from environment with value: '-march=x86-64 -mtune=generic -O2 -pipe -fno-plt'
Using 'LDFLAGS' from environment with value: '-Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now'
Using 'CPPFLAGS' from environment with value: '-D_FORTIFY_SOURCE=2'
Using 'CC' from environment with value: 'gcc -m64'
Using 'CFLAGS' from environment with value: '-march=x86-64 -mtune=generic -O2 -pipe -fno-plt'
Using 'LDFLAGS' from environment with value: '-Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now'
Using 'CPPFLAGS' from environment with value: '-D_FORTIFY_SOURCE=2'
C compiler for the host machine: gcc -m64 (gcc 10.2.0 "gcc (GCC) 10.2.0")
C linker for the host machine: gcc -m64 ld.bfd 2.35
Host machine cpu family: x86_64
Host machine cpu: x86_64
Program widl found: YES
Program glslangValidator found: NO

HansKristian-Work-vkd3d-proton/meson.build:46:0: ERROR: Program 'glslangValidator' not found

A full log can be found at /build/vkd3d-proton-tkg-git/src/vkd3d-proton-tkg-git/meson-logs/meson-log.txt
==> ERROR: A failure occurred in build().
    Aborting...
  -> Cleanup done
==> ERROR: Build failed, check /var/lib/makechrootpkg/anders/build
```

I was using the `_fork_disable_meson=true` option and that worked, but I wanted to get meson to work. 

`HansKristian-Work-vkd3d-proton/meson.build:46:0: ERROR: Program 'glslangValidator' not found` seemed to be the problem.

A quick `pacman -Fy glslangValidator` told me the program came in the package `glslang`, so I added it to the `makedepends=` in the PKGBUILD and the meson build works now. 